### PR TITLE
Use Maybe a for vector and matrix products to improve runtime and space complexity

### DIFF
--- a/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
+++ b/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
@@ -18,6 +18,13 @@ v ·· w = case M.foldl' (+) 0 $ M.intersectionWith (*) v w of
 --    where f acc 0 _ = acc
 --          f acc i x = acc + ((findWithDefault 0 i w) * x)
 
+-- | Dot product of first `IntMap` with all `IntMap`s in second `IntMap`
+--   (for internal use)
+(···) :: (Num a, Eq a) => IntMap a -> IntMap (IntMap a) -> Maybe (IntMap a)
+r ··· m = case M.mapMaybe (r ··) m of v
+                                          | M.null v  -> Nothing
+                                          | otherwise -> Just v
+
 -- | Shifts (re-enumerates) keys of IntMap by given number
 shiftKeys :: Int -> IntMap α -> IntMap α
 shiftKeys k m = M.fromAscList [ (i+k,x) | (i,x) <- M.toAscList m ]

--- a/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
+++ b/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
@@ -10,8 +10,11 @@ import Data.IntMap   as M
 -----------------------------------------
 
 -- | Dot product of two `IntMap`s (for internal use)
-(··) :: (Num α) => IntMap α -> IntMap α -> α
-v ·· w = M.foldl' (+) 0 $ M.intersectionWith (*) v w
+(··) :: (Num α, Eq α) => IntMap α -> IntMap α -> Maybe α
+v ·· w = let x = M.foldl' (+) 0 $ M.intersectionWith (*) v w
+  in case x of
+           0 -> Nothing
+           _ -> Just x
 --    M.foldlWithKey' f 0 v
 --    where f acc 0 _ = acc
 --          f acc i x = acc + ((findWithDefault 0 i w) * x)

--- a/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
+++ b/Math/LinearAlgebra/Sparse/IntMapUtilities.hs
@@ -11,10 +11,9 @@ import Data.IntMap   as M
 
 -- | Dot product of two `IntMap`s (for internal use)
 (··) :: (Num α, Eq α) => IntMap α -> IntMap α -> Maybe α
-v ·· w = let x = M.foldl' (+) 0 $ M.intersectionWith (*) v w
-  in case x of
-           0 -> Nothing
-           _ -> Just x
+v ·· w = case M.foldl' (+) 0 $ M.intersectionWith (*) v w of
+  0 -> Nothing
+  x -> Just x
 --    M.foldlWithKey' f 0 v
 --    where f acc 0 _ = acc
 --          f acc i x = acc + ((findWithDefault 0 i w) * x)

--- a/Math/LinearAlgebra/Sparse/Matrix.hs
+++ b/Math/LinearAlgebra/Sparse/Matrix.hs
@@ -384,7 +384,7 @@ mulMV :: (Num α, Eq α) => SparseMatrix α -> SparseVector α -> SparseVector �
 mulMV = (×·)
 -- | Unicode alias for `mulMV`
 (×·)  :: (Num α, Eq α) => SparseMatrix α -> SparseVector α -> SparseVector α
-(SM (h,_) m) ×· (SV _ v) = SV h (M.filter (0/=) (M.map (v··) m))  -- dot-p v with each row
+(SM (h,_) m) ×· (SV _ v) = SV h (M.mapMaybe (v··) m)  -- dot-p v with each row
 
 -- | Vector-by-matrix multiplication
 mulVM :: (Num α, Eq α) => SparseVector α -> SparseMatrix α -> SparseVector α
@@ -401,6 +401,6 @@ mul = (×)
 a × b = let d  = (height a, width b)    -- size of result
             bt = mx (trans b)           -- columns of b
             m  = M.filter (not . M.null)
-               $ M.map (\aRow -> M.filter (0/=) (M.map (aRow··) bt)) (mx a)
+               $ M.map (\aRow -> M.mapMaybe (aRow··) bt) (mx a)
             -- each row of a should be dot-multiplied on b columns
         in SM d m

--- a/Math/LinearAlgebra/Sparse/Matrix.hs
+++ b/Math/LinearAlgebra/Sparse/Matrix.hs
@@ -384,7 +384,7 @@ mulMV :: (Num α, Eq α) => SparseMatrix α -> SparseVector α -> SparseVector �
 mulMV = (×·)
 -- | Unicode alias for `mulMV`
 (×·)  :: (Num α, Eq α) => SparseMatrix α -> SparseVector α -> SparseVector α
-(SM (h,_) m) ×· (SV _ v) = SV h (M.mapMaybe (v··) m)  -- dot-p v with each row
+(SM (h,_) m) ×· (SV _ v) = SV h (M.mapMaybe (v ··) m)  -- dot-p v with each row
 
 -- | Vector-by-matrix multiplication
 mulVM :: (Num α, Eq α) => SparseVector α -> SparseMatrix α -> SparseVector α
@@ -400,7 +400,6 @@ mul = (×)
 (×) :: (Num α, Eq α) => SparseMatrix α -> SparseMatrix α -> SparseMatrix α
 a × b = let d  = (height a, width b)    -- size of result
             bt = mx (trans b)           -- columns of b
-            m  = M.filter (not . M.null)
-               $ M.map (\aRow -> M.mapMaybe (aRow··) bt) (mx a)
+            m  = M.mapMaybe (\aRow -> (aRow ···) bt) (mx a)
             -- each row of a should be dot-multiplied on b columns
         in SM d m

--- a/Math/LinearAlgebra/Sparse/Vector.hs
+++ b/Math/LinearAlgebra/Sparse/Vector.hs
@@ -39,6 +39,7 @@ import Data.Foldable as F
 import Data.List     as L
 import Data.IntMap   as M hiding ((!))
 import Data.Monoid
+import Data.Maybe
 
 
 --------------------------------------------------------------------------------
@@ -219,4 +220,4 @@ dot = (·)
 
 -- | Unicode alias for `dot`
 (·) :: (Eq α, Num α) => SparseVector α -> SparseVector α -> α
-v · w = (vec v) ·· (vec w)
+v · w = fromMaybe 0 $ (vec v) ·· (vec w) 


### PR DESCRIPTION
Hi,
I've made a simple modification in the way vector-vector, matrix-vector, and matrix-matrix products are computed.

The basic change is that `IntMapUtilities.(··)` returns `Nothing` for zero values and `Just v` for all other values. This way we can use `IntMap.mapMaybe` to process only the nonzero values. Furthermore, we can use the same idea to remove empty rows in matrix-matrix multiplications directly without filtering (for which I added the utility function `IntMapUtilities.(···)`).

This has two advantages: 
- Memory complexity: We don't create a lot of zero values or empty rows we wil never use. 
- Time complexity: We don't have to filter all the unwanted zeros and empty rows.

I've benchmarked the runtime improvement with the following small programm using https://github.com/bos/criterion

``` haskell
{-# LANGUAGE BangPatterns #-}

import Math.LinearAlgebra.Sparse
import Data.Foldable as F
import Criterion.Main

sz = 10000
v1 = vecFromAssocListWithSize sz [(1,1)]
m1 = idMx sz
m2 = trans $ fromRows $ replicate sz v1

mulMV' (!a, !b) = F.foldr (+) 0 $ mulMV a b
mul' (!a, !b) = F.foldr (+) 0 $ fmap (F.foldr (+) 0) $ rows $ mul a b

main = defaultMain [ bgroup "mulMV"
                     [ bench "mulMV" $ whnf mulMV' (m1, v1)
                     , bench "mul"  $ whnf mul' (m1, m2)
                     ]
                   ]
```
##### Runtime with zeros + filter:

```
benchmarking mulMV/mulMV
time                 1.719 ms   (1.698 ms .. 1.737 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.699 ms   (1.691 ms .. 1.709 ms)
std dev              29.51 μs   (23.06 μs .. 40.26 μs)

benchmarking mulMV/mul
time                 18.75 s    (18.15 s .. 19.67 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.04 s    (18.91 s .. 19.11 s)
std dev              111.3 ms   (0.0 s .. 114.0 ms)
variance introduced by outliers: 19% (moderately inflated)
```
##### Runtime with Maybe

```
benchmarking mulMV/mulMV
time                 557.7 μs   (551.8 μs .. 563.8 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 558.3 μs   (554.3 μs .. 564.8 μs)
std dev              16.76 μs   (12.21 μs .. 25.13 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarking mulMV/mul
time                 5.865 s    (5.762 s .. 6.008 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.816 s    (5.769 s .. 5.843 s)
std dev              41.77 ms   (0.0 s .. 46.03 ms)
```

So we would get roughly a 3x speedup with `Maybe` when there are a lot of zero values and empty rows.
