### PR TITLE
Assoc list, fixes issue #7

### DIFF
--- a/Math/LinearAlgebra/Sparse/Matrix.hs
+++ b/Math/LinearAlgebra/Sparse/Matrix.hs
@@ -349,8 +349,11 @@ fromAssocListWithSize s l = L.foldl' ins (zeroMx s) l
 
 -- | Converts associative list to sparse matrix,
 --   using maximal index as matrix size
-fromAssocList :: (Num α, Eq α) => [ ((Index,Index), α) ] -> SparseMatrix α 
-fromAssocList l = fromAssocListWithSize (L.maximum $ fmap fst l) l
+fromAssocList :: (Num α, Eq α) => [ ((Index,Index), α) ] -> SparseMatrix α
+fromAssocList l = fromAssocListWithSize (size is) l
+    where is = fmap fst l
+          size [] = (0, 0)
+          size xs = (L.maximum $ fmap fst is, L.maximum $ fmap snd is)
 
 -- | Converts sparse matrix to plain list-matrix with all zeroes restored
 fillMx :: (Num α) => SparseMatrix α -> [[α]]

--- a/Math/LinearAlgebra/Sparse/Matrix.hs
+++ b/Math/LinearAlgebra/Sparse/Matrix.hs
@@ -339,26 +339,25 @@ fromRows = F.foldl' (<|) emptyMx
 -- | Converts sparse matrix to associative list,
 --   adding fake zero element, to save real size for inverse conversion
 toAssocList :: (Num α, Eq α) => SparseMatrix α -> [ ((Index,Index), α) ]
-toAssocList (SM s m) = (s, 0) : 
-    [ ((i,j), x) | (i,row) <- M.toAscList m, (j,x) <- M.toAscList row, x /= 0 ] 
+toAssocList (SM s m) = (s, 0) :
+    [ ((i,j), x) | (i,row) <- M.toAscList m, (j,x) <- M.toAscList row, x /= 0 ]
 
 -- | Converts associative list to sparse matrix,
 --   of given size
-fromAssocListWithSize :: (Num α, Eq α) => (Int,Int) -> [ ((Index,Index), α) ] -> SparseMatrix α 
-fromAssocListWithSize s l = L.foldl' ins (zeroMx s) l 
+fromAssocListWithSize :: (Num α, Eq α) => (Int,Int) -> [ ((Index,Index), α) ] -> SparseMatrix α
+fromAssocListWithSize s l = L.foldl' ins (zeroMx s) l
 
 -- | Converts associative list to sparse matrix,
 --   using maximal index as matrix size
 fromAssocList :: (Num α, Eq α) => [ ((Index,Index), α) ] -> SparseMatrix α
-fromAssocList l = fromAssocListWithSize (size is) l
-    where is = fmap fst l
-          size [] = (0, 0)
-          size xs = (L.maximum $ fmap fst is, L.maximum $ fmap snd is)
+fromAssocList l = fromAssocListWithSize size l
+    where size = L.foldl maxIndices (0, 0) l
+          maxIndices (mX, mY) ((x, y), _) = (max mX x, max mY y)
 
 -- | Converts sparse matrix to plain list-matrix with all zeroes restored
 fillMx :: (Num α) => SparseMatrix α -> [[α]]
-fillMx m = [ [ m # (i,j) | j <- [1 .. width  m] ]
-                         | i <- [1 .. height m] ]
+fillMx m = [ [ m # (i,j) | j <- [0 .. width  m] ]
+                         | i <- [0 .. height m] ]
 
 -- | Converts plain list-matrix to sparse matrix, throwing out all zeroes
 sparseMx :: (Num α, Eq α) => [[α]] -> SparseMatrix α


### PR DESCRIPTION
This fixes issue #7.

Incorrect behavior before:

```
*Math.LinearAlgebra.Sparse> fromAssocList [((1,2), 3), ((0, 100), 3)]
(1,2): 
[ |3]
```

Current behavior:

```
*Math.LinearAlgebra.Sparse> fromAssocList [((1,2), 3), ((0, 100), 3)]
(2,101): 
[ | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |3]
[ | |3| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | ]
```