### PR TITLE
fixing fromAssocList bug

### DIFF
--- a/Math/LinearAlgebra/Sparse/Matrix.hs
+++ b/Math/LinearAlgebra/Sparse/Matrix.hs
@@ -349,8 +349,10 @@ fromAssocListWithSize s l = L.foldl' ins (zeroMx s) l
 
 -- | Converts associative list to sparse matrix,
 --   using maximal index as matrix size
-fromAssocList :: (Num α, Eq α) => [ ((Index,Index), α) ] -> SparseMatrix α 
-fromAssocList l = fromAssocListWithSize (L.maximum $ fmap fst l) l
+fromAssocList :: (Num α, Eq α) => [ ((Index,Index), α) ] -> SparseMatrix α
+fromAssocList l = fromAssocListWithSize size l
+    where size = L.foldl maxIndices (0, 0) l
+          maxIndices (mX, mY) ((x, y), _) = (max mX x, max mY y)
 
 -- | Converts sparse matrix to plain list-matrix with all zeroes restored
 fillMx :: (Num α) => SparseMatrix α -> [[α]]


### PR DESCRIPTION
fixes #7 

incorrect behavior:

```
*Math.LinearAlgebra.Sparse> fromAssocList [((3,2), 3), ((1, 100), 3)]
(3,2): 
[ | ]
[ | ]
[ |3]
```

after bug-fix:
```
*Math.LinearAlgebra.Sparse> fromAssocList [((3,2), 3), ((1, 100), 3)]
(3,100): 
[ | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |3]
[ | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | ]
[ |3| | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | ]
```

tests pass!